### PR TITLE
Tweak to TextureRedrawer.getHash

### DIFF
--- a/src/com/company/assembleegameclient/util/TextureRedrawer.as
+++ b/src/com/company/assembleegameclient/util/TextureRedrawer.as
@@ -45,7 +45,7 @@ public class TextureRedrawer {
     }
 
     private static function getHash(size:int, padBottom:Boolean, glowColor:uint, sMult:Number):* {
-        var h:int = (padBottom ? (1 << 31) : 0) | (size * sMult);
+        var h:int = (padBottom ? (1 << 27) : 0) | (size * sMult);
         if (glowColor == 0) {
             return h;
         }


### PR DESCRIPTION
Avoids unnecessary conversion to string when a dictionary lookup happens
with the int.

For ref:
https://stackoverflow.com/questions/9447698/large-numbers-as-keys-in-dictionaries-actionscript-3